### PR TITLE
Use hcalendar

### DIFF
--- a/eolclub_scraper.gemspec
+++ b/eolclub_scraper.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'nokogiri'
-  spec.add_dependency 'chronic'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/eolclub_scraper/event_parser.rb
+++ b/lib/eolclub_scraper/event_parser.rb
@@ -11,12 +11,13 @@ module EolclubScraper
     def parse(content)
       doc = Nokogiri::HTML.parse(content)
       description = doc.css('p').first(3).map(&:to_html).join
-      schedule_text = doc.css('p')[1].text.split("\n")[2].split(',').last.strip.split
-      start_time, end_time = schedule_text.last.split(/\W/)
+
+      start_time = doc.css('abbr.dtstart').first.attributes['title'].value
+      end_time = doc.css('abbr.dtend').first.attributes['title'].value
 
       Event.new(
-        Chronic.parse( [ schedule_text[0], schedule_text[1], start_time ].join(' ') ),
-        Chronic.parse( [ schedule_text[0], schedule_text[1], end_time ].join(' ') ),
+        Time.parse(start_time),
+        Time.parse(end_time),
         description
       )
     end

--- a/lib/eolclub_scraper/event_parser.rb
+++ b/lib/eolclub_scraper/event_parser.rb
@@ -1,6 +1,5 @@
 require 'eolclub_scraper/event'
 require 'nokogiri'
-require 'chronic'
 
 module EolclubScraper
 

--- a/spec/eolclub_scraper/event_parser_spec.rb
+++ b/spec/eolclub_scraper/event_parser_spec.rb
@@ -8,8 +8,8 @@ describe EolclubScraper::EventParser do
 
     it 'parses an Event from the supplied content' do
       Timecop.freeze(Time.local(2013, 12, 28)) do
-        expect( parsed.start_time ).to eq( Time.local(2014, 1, 13, 18, 0, 0) )
-        expect( parsed.end_time ).to eq( Time.local(2014, 1, 13, 23, 0, 0) )
+        expect( parsed.start_time ).to eq( Time.parse("2014-01-13T18:00:00-05:00") )
+        expect( parsed.end_time ).to eq( Time.parse("2014-01-13T23:00:00-05:00") )
       end
     end
 

--- a/spec/eolclub_scraper/event_parser_spec.rb
+++ b/spec/eolclub_scraper/event_parser_spec.rb
@@ -16,7 +16,7 @@ describe EolclubScraper::EventParser do
     it 'provides the HTML description from the scraped page' do
       desc = parsed.description
       expect(desc).to include("Monthly Providence, RI hacknight.")
-      expect(desc).to include("Our next meetup is")
+      expect(desc).to match(/The next.*EOL Club.*meetup is/m)
       expect(desc).to include("@EOLclub")
     end
   end

--- a/spec/eolclub_scraper/event_parser_spec.rb
+++ b/spec/eolclub_scraper/event_parser_spec.rb
@@ -8,8 +8,8 @@ describe EolclubScraper::EventParser do
 
     it 'parses an Event from the supplied content' do
       Timecop.freeze(Time.local(2013, 12, 28)) do
-        expect( parsed.start_time ).to eq( Time.local(2013, 12, 9, 18, 0, 0) )
-        expect( parsed.end_time ).to eq( Time.local(2013, 12, 9, 23, 0, 0) )
+        expect( parsed.start_time ).to eq( Time.local(2014, 1, 13, 18, 0, 0) )
+        expect( parsed.end_time ).to eq( Time.local(2014, 1, 13, 23, 0, 0) )
       end
     end
 
@@ -40,17 +40,20 @@ describe EolclubScraper::EventParser do
             <h1>End of Line Club</h1>
           </header>
           <section id='main'>
-            <p>
-              Monthly Providence, RI hacknight. Code, design, and collaborate
-              with other local developers to a backdrop of electronic music.
-              Bring your laptop and a project to work on.
-            </p>
-            <p>
-              Our next meetup is
-              Monday, December 9th from 6pm&ndash;11pm
-              at <a href='http://basicsgroup.com'>Basics Group</a>.
-              Arrive whenever you can. Pizza and beer provided.
-            </p>
+            <div class="vevent">
+              <p class="description">
+                Monthly Providence, RI hacknight. Code, design, and collaborate
+                with other local developers to a backdrop of electronic music.
+                Bring your laptop and a project to work on.
+              </p>
+              <p>
+                The next <span class="summary">EOL Club</span>
+                meetup is Monday, January 13th from
+                <abbr class="dtstart" title="2014-01-13T18:00:00-05:00">6pm</abbr>&ndash;<abbr class="dtend" title="2014-01-13T23:00:00-05:00">11pm</abbr>
+                at <a class="location" href="http://basicsgroup.com">Basics Group</a>.
+                Arrive whenever you can. Food and beer provided.
+              </p>
+            </div>
             <p>
               <a href="https://twitter.com/EOLclub">@EOLclub</a>
               to get more info and RSVP.


### PR DESCRIPTION
I broke your scraper when I restructured eolclub.org ever so slightly. This PR fixes it, and also conveniently removes the Chronic dependency.

Supercedes PR #2.  I think this solution to the timezone issue (27de26c) is slightly preferable to the one from my previous attempt (21c7b7d).  Neither are great, but the previous one required manual conversion of the times in the sample content to UTC.

You can modify the timezone ruby works in by setting TZ in your shell before startup (e.g. set to "UTC" to simulate Travis' environment).  There doesn't seem to be a way to modify it once the interpreter is running, however.
